### PR TITLE
Add check whether snap to perform snap

### DIFF
--- a/lib/src/main/java/me/onebone/toolbar/ScrollStrategy.kt
+++ b/lib/src/main/java/me/onebone/toolbar/ScrollStrategy.kt
@@ -292,9 +292,9 @@ internal class ExitUntilCollapsedNestedScrollConnection(
 // TODO: Is there a better solution rather OptIn ExperimentalToolbarApi?
 @OptIn(ExperimentalToolbarApi::class)
 private suspend fun CollapsingToolbarState.performSnap(snapConfig: SnapConfig) {
-	if (progress > snapConfig.edge) {
+	if (progress > snapConfig.edge && progress < 1f) {
 		expand(snapConfig.expandDuration)
-	} else {
+	} else if (progress <= snapConfig.edge && progress > 0f){
 		collapse(snapConfig.collapseDuration)
 	}
 }


### PR DESCRIPTION
- when toolbar is expanded or collapsed fully, do not perform snap (as it is not needed), this is the case, when progress == 0 or 1
- this improves performance and fixes a bug with horizontal scrolling in the CollapsingToolbarScaffold content